### PR TITLE
Stop using a __memoized property. (Once 2.0?)

### DIFF
--- a/src/MemoizeAwareTrait.php
+++ b/src/MemoizeAwareTrait.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Spatie\Once;
-
-trait MemoizeAwareTrait
-{
-    protected $__memoized;
-}

--- a/src/Purse.php
+++ b/src/Purse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spatie\Once;
+
+class Purse
+{
+    /**
+     * The cached values.
+     *
+     * @var array
+     */
+    public static $values = [];
+
+    /**
+     * Determine if a value exists for a given object / hash.
+     *
+     * @param  mixed  $object
+     * @param  string  $hash
+     * @return bool
+     */
+    public static function has($object, string $hash): bool
+    {
+        $mainHash = spl_object_hash($object);
+
+        return isset(static::$values[$mainHash]) &&
+               array_key_exists($hash, static::$values[$mainHash]);
+    }
+
+    /**
+     * Retrieve a value for an object / hash.
+     *
+     * @param  mixed  $object
+     * @param  string  $hash
+     * @return mixed
+     */
+    public static function get($object, string $hash)
+    {
+        return static::$values[spl_object_hash($object)][$hash];
+    }
+
+    /**
+     * Set a cached value for an object / hash.
+     *
+     * @param  mixed  $object
+     * @param  string  $hash
+     * @param  mixed  $value
+     * @return void
+     */
+    public static function set($object, string $hash, $value)
+    {
+        static::$values[spl_object_hash($object)][$hash] = $value;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\Once\Purse;
 use Spatie\Once\Backtrace;
 
 function once($callback)
@@ -16,13 +17,13 @@ function once($callback)
 
     $hash = $backtrace->getHash();
 
-    $cacheHit = isset($object->__memoized) && array_key_exists($hash, $object->__memoized);
+    $cacheHit = Purse::has($object, $hash);
 
     if (! $cacheHit) {
         $result = call_user_func($callback, $backtrace->getArguments());
 
-        $object->__memoized[$hash] = $result;
+        Purse::set($object, $hash, $result);
     }
 
-    return $object->__memoized[$hash];
+    return Purse::get($object, $hash);
 }


### PR DESCRIPTION
This tweak just uses a simple "Purse" object to cache all the cache hits instead of putting the values on a hidden property on the object itself. This solves a few problems: 1) don't have to ever think about sleep / wakeup. 2) no need for a MemoizeAware trait to avoid weird overloading errors, etc.

I'm guessing if merged this would require a 2.0 tag since I removed the trait as it is no longer ever necessary.

All tests pass without changes.

If this is accepted I'm considering just including it in Laravel 5.6.

Let me know what you think :smile: