### PR TITLE
Changed memorization → memoization in readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A magic memorization function
+# A magic [memoization](https://en.wikipedia.org/wiki/Memoization) function
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/once.svg?style=flat-square)](https://packagist.org/packages/spatie/once)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)


### PR DESCRIPTION
I saw an old pull request which changed the _memoization_ to _memorization_ but since the function is actually a [memoization](https://en.wikipedia.org/wiki/Memoization) one and that is what it is doing. Memorization doesn't fit well here. So, I'm reverting it back to _memoization_ along with the source link to description of the same.