### PR TITLE
Differentiate between closures

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -7,9 +7,13 @@ class Backtrace
     /** @var array */
     protected $trace;
 
+    /** @var array */
+    protected $zeroStack;
+
     public function __construct(array $trace)
     {
-        $this->trace = $trace;
+        $this->trace = $trace[1];
+        $this->zeroStack = $trace[0];
     }
 
     public function getArguments(): array
@@ -36,7 +40,12 @@ class Backtrace
             return is_object($argument) ? spl_object_hash($argument) : $argument;
         }, $this->getArguments());
 
-        return md5($this->getFunctionName().serialize($normalizedArguments));
+        $prefix = $this->getFunctionName();
+        if (strpos($prefix, '{closure}') !== false) {
+            $prefix = $this->zeroStack['line'];
+        }
+
+        return md5($prefix.serialize($normalizedArguments));
     }
 
     protected function staticCall()

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,11 +7,11 @@ function once($callback)
 {
     $trace = debug_backtrace(
         DEBUG_BACKTRACE_PROVIDE_OBJECT, 2
-    )[1];
+    );
 
     $backtrace = new Backtrace($trace);
 
-    if ($trace['function'] === 'eval') {
+    if ($backtrace->getFunctionName() === 'eval') {
         return call_user_func($callback);
     }
 

--- a/tests/OnceTest.php
+++ b/tests/OnceTest.php
@@ -224,4 +224,57 @@ class OnceTest extends TestCase
 
         $this->assertTrue(in_array($result, range(1, 1000)));
     }
+
+    /** @test */
+    public function it_will_differentiate_between_closures()
+    {
+        $testClass = new class() {
+            public function getNumber()
+            {
+                $closure = function () {
+                    return once(function () {
+                        return random_int(1, 1000);
+                    });
+                };
+
+                return $closure();
+            }
+
+            public function secondNumber()
+            {
+                $closure = function () {
+                    return once(function () {
+                        return random_int(1001, 2000);
+                    });
+                };
+
+                return $closure();
+            }
+        };
+
+        $this->assertNotEquals($testClass->getNumber(), $testClass->secondNumber());
+    }
+
+    /** @test */
+    public function it_will_run_callback_once_for_closure_called_on_differemt_lines()
+    {
+        $testClass = new class() {
+            public function getNumbers()
+            {
+                $closure = function () {
+                    return once(function () {
+                        return random_int(1, 10000000);
+                    });
+                };
+
+                $numbers[] = $closure();
+                $numbers[] = $closure();
+
+                return $numbers;
+            }
+        };
+
+        $results = $testClass->getNumbers();
+        $this->assertEquals($results[0], $results[1]);
+    }
 }


### PR DESCRIPTION
This package uses function name in a hash calculation. For closures, function name will always be "namespace\{closure}", therefore calculated hash will be always the same, if arguments also match. This raises a problem, since once() will be run only once regardless of the method it is nested in and return the same result across methods.

What I did here is, that the hashing method checks, if once() was called from within a closure and instead of using generic function name, it uses the line number of once() call. 


Here is an example, how I got an idea for even using once() in a closure:
```
public function getSomething($element)
{
    $getData = function () {
        return once(function () {
            // An expensive function call that does not depend on
            // method's arguments.
        });
    };

    retrun $getData()[$element];
}
```

If I was to use once() outside the closure, it would take $element argument into consideration, so every time the method would be called with a different argument, once() would call its closure. Now with once() being in a closure, the arguments (there are none in the example) are always the same and the calculated hash will match every time).

I could of course extract this expensive function call in its own method, but sometimes you would only need that part one time, so declaring a separate method seems overkill and using closure just seems more "right".

I also included two tests which demonstrate the functionality of this PR.

Bonus: If you wrap once() in a closure, you can also have multiple such occurances per method giving you different results.  Currently you can only have one once() per method because every next one will return you the result of the first one.