### PR TITLE
Support global functions

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -31,6 +31,10 @@ class Backtrace
      */
     public function getObject()
     {
+        if ($this->globalFunction()) {
+            return $this->zeroStack['file'];
+        }
+
         return $this->staticCall() ? $this->trace['class'] : $this->trace['object'];
     }
 
@@ -51,5 +55,10 @@ class Backtrace
     protected function staticCall()
     {
         return $this->trace['type'] == '::';
+    }
+
+    protected function globalFunction()
+    {
+        return ! isset($this->trace['type']);
     }
 }

--- a/tests/OnceTest.php
+++ b/tests/OnceTest.php
@@ -277,4 +277,17 @@ class OnceTest extends TestCase
         $results = $testClass->getNumbers();
         $this->assertEquals($results[0], $results[1]);
     }
+
+    /** @test */
+    public function it_will_work_in_global_functions()
+    {
+        function globalFunction()
+        {
+            return once(function () {
+                return random_int(1, 10000000);
+            });
+        }
+
+        $this->assertEquals(globalFunction(), globalFunction());
+    }
 }


### PR DESCRIPTION
A follow up from #41.

It's a pretty simple change. When once() is called from a global function, it will use file name as a cache identifier (currently it tries to use class name / instance which obviously doesn't exist and errors out).

I also included a test to make sure it's working.