### PR TITLE
Use an instantiated class in the documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@
 This package contains a `once` function. You can pass a `callable` to it. Here's quick example:
 
 ```php
-class MyClass
-{
+$myClass = new class() {
     public function getNumber()
     {
         return once(function () {
             return rand(1, 10000);
         });
     }
-}
+};
 ```
 
-No matter how many times you run `(new MyClass())->getNumber()` inside the same request  you'll always get the same number.
+No matter how many times you run `$myClass->getNumber()` inside the same request  you'll always get the same number.
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
@@ -45,18 +44,17 @@ composer require spatie/once
 The `once` function accepts a `callable`.
 
 ```php
-class MyClass
-{
+$myClass = new class() {
     public function getNumber()
     {
         return once(function () {
             return rand(1, 10000);
         });
     }
-}
+};
 ```
 
-No matter how many times you run `(new MyClass())->getNumber()` you'll always get the same number.
+No matter how many times you run `$myClass->getNumber()` you'll always get the same number.
 
 The `once` function will only run once per combination of argument values the containing method receives.
 


### PR DESCRIPTION
The examples aren't correct, `(new MyClass())->getNumber()` isn't repeatable.

I think each call creates a new instance with a unique hash, but also that they're destroyed and removed from the cache straight away.

This behaviour appears to go right back to v0.0.1, which makes me think it's a documentation issue rather than an implementation one?

```
<?php

require_once 'vendor/autoload.php';

class MyClass
{
    public function getNumber()
    {
        return once(function () {
            return rand(1, 10000);
        });
    }
}

var_dump([
    (new MyClass())->getNumber(),
    (new MyClass())->getNumber(),
    (new MyClass())->getNumber(),
]); // All different


$myClass = new MyClass();

var_dump([
    $myClass->getNumber(),
    $myClass->getNumber(),
    $myClass->getNumber(),
]); // All the same
```