### PR TITLE
Allow php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "require-dev": {
         "larapack/dd": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.2|^8.0"
     },
     "require-dev": {
         "larapack/dd": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
         "larapack/dd": "^1.1",


### PR DESCRIPTION
Currently composer reports a problem when using php8:
```
Problem 1
    - Root composer.json requires spatie/once ^2.2.0 -> satisfiable by spatie/once[2.2.0].
    - spatie/once 2.2.0 requires php ^7.2 -> your php version (8.0.0RC2) does not satisfy that requirement.
```

this PR should fix it.