### PR TITLE
add static variables of callback to signature

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -22,7 +22,13 @@ class Backtrace
 
     public function getFunctionName(): string
     {
-        return $this->trace['function'];
+        $function = $this->trace['function'];
+
+        if (str_contains($function, '{closure}')) {
+            $function .= '#'.$this->zeroStack['line'];
+        }
+
+        return $function;
     }
 
     public function getObject(): mixed
@@ -32,20 +38,6 @@ class Backtrace
         }
 
         return $this->staticCall() ? $this->trace['class'] : $this->trace['object'];
-    }
-
-    public function getHash(): string
-    {
-        $normalizedArguments = array_map(function ($argument) {
-            return is_object($argument) ? spl_object_hash($argument) : $argument;
-        }, $this->getArguments());
-
-        $prefix = $this->getFunctionName();
-        if (str_contains($prefix, '{closure}')) {
-            $prefix = $this->zeroStack['line'];
-        }
-
-        return md5($prefix.serialize($normalizedArguments));
     }
 
     protected function staticCall(): bool

--- a/src/ReflectionCallable.php
+++ b/src/ReflectionCallable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\Once;
+
+use BadMethodCallException;
+use Closure;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
+
+/**
+ * @mixin \ReflectionFunction
+ * @mixin \ReflectionMethod
+ */
+class ReflectionCallable
+{
+    protected ReflectionFunctionAbstract $reflection;
+
+    public function __construct(callable $callable)
+    {
+        if ($callable instanceof Closure) {
+            $this->reflection = new ReflectionFunction($callable);
+        } elseif (is_string($callable)) {
+            $parts = explode('::', $callable);
+
+            $this->reflection = count($parts) > 1
+                ? new ReflectionMethod($parts[0], $parts[1])
+                : new ReflectionFunction($callable);
+        } else {
+            if (!is_array($callable)) {
+                $callable = [$callable, '__invoke'];
+            }
+
+            $this->reflection = new ReflectionMethod($callable[0], $callable[1]);
+        }
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        if(method_exists($this->reflection, $name)) {
+            return call_user_func_array([$this->reflection, $name], $arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Undefined method %s->%s()', $this::class, $name));
+    }
+}


### PR DESCRIPTION
fixes #59

The arguments of the surrounding method are now only used in the signature if the closure has arguments (#58) and the static variables `use` are now part of the cache signature.
I've also switched to `sha256` to have longer keys and less possible conflict.