### PR TITLE
Two static functions with the same name

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -25,6 +25,11 @@ class Backtrace
         return $this->trace['function'];
     }
 
+    public function getObjectName(): ?string
+    {
+        return $this->trace['class'] ?? null;
+    }
+
     public function getObject(): mixed
     {
         if ($this->globalFunction()) {
@@ -40,7 +45,7 @@ class Backtrace
             return is_object($argument) ? spl_object_hash($argument) : $argument;
         }, $this->getArguments());
 
-        $prefix = $this->getFunctionName();
+        $prefix = $this->getObjectName() . $this->getFunctionName();
         if (str_contains($prefix, '{closure}')) {
             $prefix = $this->zeroStack['line'];
         }

--- a/tests/OnceTest.php
+++ b/tests/OnceTest.php
@@ -280,4 +280,30 @@ class OnceTest extends TestCase
 
         $this->assertEquals(globalFunction(), globalFunction());
     }
+
+    /** @test */
+    public function it_will_works_with_two_static_functions_with_the_same_name()
+    {
+        $a = new class() {
+            public static function getName()
+            {
+                return once(function () {
+                    return 'A';
+                });
+            }
+        };
+        $b = new class() {
+            public static function getName()
+            {
+                return once(function () {
+                    return 'B';
+                });
+            }
+        };
+        $aClass = get_class($a);
+        $bClass = get_class($b);
+
+        $this->assertEquals('A', $aClass::getName());
+        $this->assertEquals('B', $bClass::getName());
+    }
 }


### PR DESCRIPTION
If two static functions have the same name (in two different classes), the `once` cache is shared between the two resulting in wrong response during the second call (we can invert the two calls, the second one is always the wrong one).

I've just added a failing test. I read a little bit the code but didn't find the correct way to fix the bug…

In the `once` function, the `$object` variable is different for the two classes but the `$hash` is the same.