### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.1, 8.0]
+                php: [8.0, 8.1, 8.2]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,9 @@ jobs:
                   extensions: json, dom, curl, libxml, mbstring
                   coverage: none
 
+            - name: Allow Pest Composer plugin
+              run: composer config --no-plugins allow-plugins.pestphp/pest-plugin true
+
             - name: Install dependencies
               run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow.

It also allows the pest plugin for composer to execute during the workflow.