### PR TITLE
Add onceIf() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ $myClass = new class() {
 
 No matter how many times you run `$myClass->getNumber()` inside the same request  you'll always get the same number.
 
+However, if you want to reuse the result only if a given condition is `true`, you can use `onceIf()`, passing as first parameter a `bool` expression or a `callable`:
+
+```php
+$myClass = new class() {
+    public function getSameNumber(): int
+    {
+        return onceIf(fn() => true, function () {
+            return rand(1, 10000);
+        });
+    }
+    
+    public function getDifferentNumber(): int
+    {
+        return onceIf(fn() => false, function () {
+            return rand(1, 10000);
+        });
+    }
+};
+```
+
 ## Are you a visual learner?
 
 Under the hood, this package uses a PHP 8 Weakmap. [In this video](https://www.youtube.com/watch?v=-lFyHJqzfFU&list=PLjzBMxW2XGTwEwWumYBaFHy1z4W32TcjU&index=13), you'll see what a weakmap is, together with a nice demo of the package.

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,5 @@
     },
     "config": {
         "sort-packages": true
-  }
+    }
 }

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -10,9 +10,9 @@ class Backtrace
 
     public function __construct(array $trace)
     {
-        $this->trace = $trace[1];
+        $this->trace = $trace[2];
 
-        $this->zeroStack = $trace[0];
+        $this->zeroStack = $trace[1];
     }
 
     public function getArguments(): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,8 +11,32 @@ use Spatie\Once\Cache;
  */
 function once(callable $callback): mixed
 {
+    return onceGenerics(true, $callback);
+}
+
+/**
+ * @template T
+ *
+ * @param (callable(): T)|bool $callback
+ * @param (callable(): T) $callback
+ * @return T
+ */
+function onceIf(callable|bool $condition, callable $callback): mixed
+{
+    return onceGenerics($condition, $callback);
+}
+
+/**
+ * @template T
+ *
+ * @param (callable(): T)|bool $callback
+ * @param (callable(): T) $callback
+ * @return T
+ */
+function onceGenerics(callable|bool  $condition, callable $callback): mixed
+{
     $trace = debug_backtrace(
-        DEBUG_BACKTRACE_PROVIDE_OBJECT, 2
+        DEBUG_BACKTRACE_PROVIDE_OBJECT, 3
     );
 
     $backtrace = new Backtrace($trace);
@@ -35,7 +59,9 @@ function once(callable $callback): mixed
         return call_user_func($callback, $backtrace->getArguments());
     }
 
-    if (! $cache->has($object, $hash)) {
+    $condition = is_callable($condition) ? $condition() : $condition;
+
+    if (! $cache->has($object, $hash) || ! $condition) {
         $result = call_user_func($callback, $backtrace->getArguments());
 
         $cache->set($object, $hash, $result);

--- a/tests/OnceIfTest.php
+++ b/tests/OnceIfTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Spatie\Once\Test;
+
+use Spatie\Once\Cache;
+
+beforeEach(function () {
+    $this->cache = Cache::getInstance();
+    $this->cache->enable();
+    $this->cache->flush();
+});
+
+it('will run the given callback without arguments only once, if condition is true', function () {
+    $testClass = new class() {
+        public function getNumber()
+        {
+            return onceIf(true, function () {
+                return rand(1, 10000000);
+            });
+        }
+    };
+
+    $firstResult = $testClass->getNumber();
+
+    expect($firstResult)->toBeGreaterThanOrEqual(1);
+    expect($firstResult)->toBeLessThanOrEqual(10000000);
+
+    foreach (range(1, 100) as $i) {
+        expect($testClass->getNumber())->toBe($firstResult);
+    }
+});
+
+it('will run the given callback without arguments several times, if condition is false', function () {
+    $testClass = new class() {
+        public function getNumber()
+        {
+            return onceIf(false, function () {
+                return rand(1, 10000000);
+            });
+        }
+    };
+
+    $firstResult = $testClass->getNumber();
+
+    expect($firstResult)->toBeGreaterThanOrEqual(1);
+    expect($firstResult)->toBeLessThanOrEqual(10000000);
+
+    foreach (range(1, 100) as $i) {
+        expect($testClass->getNumber())->not()->toBe($firstResult);
+    }
+});
+
+it('will run the given callback without arguments only once, if condition is a "true" callable', function () {
+    $testClass = new class() {
+        public function getNumber()
+        {
+            return onceIf(fn() => true, function () {
+                return rand(1, 10000000);
+            });
+        }
+    };
+
+    $firstResult = $testClass->getNumber();
+
+    expect($firstResult)->toBeGreaterThanOrEqual(1);
+    expect($firstResult)->toBeLessThanOrEqual(10000000);
+
+    foreach (range(1, 100) as $i) {
+        expect($testClass->getNumber())->toBe($firstResult);
+    }
+});
+
+it('will run the given callback without arguments several times, if condition is a "false" callable', function () {
+    $testClass = new class() {
+        public function getNumber()
+        {
+            return onceIf(fn() => false, function () {
+                return rand(1, 10000000);
+            });
+        }
+    };
+
+    $firstResult = $testClass->getNumber();
+
+    expect($firstResult)->toBeGreaterThanOrEqual(1);
+    expect($firstResult)->toBeLessThanOrEqual(10000000);
+
+    foreach (range(1, 100) as $i) {
+        expect($testClass->getNumber())->not()->toBe($firstResult);
+    }
+});


### PR DESCRIPTION
This PR adds the support for a `onceIf()` function, which behaves like the original `once()` function but caches results only if a provided boolean expression or callback returns true.

I had to add also a generic `onceGenerics()` function because if I treated `once()` as a special case of `onceIf()` the `Backtrace` class would have mess with the trace levels. Thus, both a `once()` and `onceIf()` are special cases of `onceGenerics()`. In this way there is still a uniform number of trace levels to reason onto to check if a value should be cached or not.

Please evaluate if this could be useful. If so, I'll try to push the same modifications on the Laravel framework as well.

Thanks!