### PR TITLE
Update Backtrace.php

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -42,7 +42,7 @@ class Backtrace
     public function getHash(): string
     {
         $normalizedArguments = array_map(function ($argument) {
-            return is_object($argument) ? spl_object_hash($argument) : $argument;
+            return is_object($argument) ? (spl_object_hash($argument) . serialize($argument)) : $argument;
         }, $this->getArguments());
 
         $prefix = $this->getObjectName() . $this->getFunctionName();


### PR DESCRIPTION
Take into consideration not only object hash, but also its properties.

Encountered in relatively rare case when the same singleton object could contain different properties that matter.

!!! Attention: could affect performance -- `spl_object_hash` is much faster than `serialize` for complex objects. !!!

As an alternative to this commit, I could create another one in which some $param argument is passed. 

Something like `once(callable $callback, array $params = []);`. One of this param could be used to define object normalization.